### PR TITLE
Update documetation for Java syntax usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ dependencies {
 *Java*
 
  ```
- LoadingDialog dialog = LoadingDialog.get(this).show();
+ LoadingDialog dialog = LoadingDialog.Companion.get(this).show();
 
 // later dismiss
 dialog.hide()


### PR DESCRIPTION
Sample usage for Java can not be used because not calling object Companion first.